### PR TITLE
Add Makefile and docker-compose.yml for running the application and benchmarking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.DEFAULT_GOAL := help
+
+OS   := $(shell uname | awk '{print tolower($$0)}')
+ARCH := $(shell case $$(uname -m) in (x86_64) echo amd64 ;; (aarch64) echo arm64 ;; (*) echo $$(uname -m) ;; esac)
+
+.PHONY: run/bench
+run/bench: ## Run bench docker compose ## make run/bench
+	docker compose up bench
+
+.PHONY: run/all
+run/all: ## Run all docker compose ## make run/all
+	docker compose --profile all up --attach db --attach app --attach web
+
+.PHONY: help
+help: ## Display this help screen ## make or make help
+	@echo ""
+	@echo "Usage: make SUB_COMMAND argument_name=argument_value"
+	@echo ""
+	@echo "Command list:"
+	@echo ""
+	@printf "\033[36m%-30s\033[0m %-50s %s\n" "[Sub command]" "[Description]" "[Example]"
+	@grep -E '^[/a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | perl -pe 's%^([/a-zA-Z_-]+):.*?(##)%$$1 $$2%' | awk -F " *?## *?" '{printf "\033[36m%-30s\033[0m %-50s %s\n", $$1, $$2, $$3}'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,62 @@
+version: '3'
+services:
+  bench:
+    build:
+      context: .
+      dockerfile: docker/bench/Dockerfile
+    networks:
+      - frontend
+    profiles:
+      - bench
+  web:
+    build:
+      context: .
+      dockerfile: docker/web/Dockerfile
+    networks:
+      - frontend
+      - backend
+    depends_on:
+      - app
+    ports:
+      - "80:80"
+    profiles:
+      - web
+      - all
+      - bench
+  app:
+    build:
+      context: .
+      dockerfile: docker/app/golang/Dockerfile
+    networks:
+      - backend
+    depends_on:
+       - db
+    ports:
+      - "5000"
+    environment:
+      ISUBATA_DB_USER: isucon
+      ISUBATA_DB_PASSWORD: isucon
+      ISUBATA_DB_HOST: db
+    profiles:
+      - app
+      - all
+  db:
+    build:
+      context: .
+      dockerfile: docker/db/Dockerfile
+    ports:
+      - "3306"
+    networks:
+      - backend
+    command: ["--character-set-server=utf8mb4"]
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      #MYSQL_DATABASE: isubata
+      #MYSQL_USER: isucon
+      #MYSQL_PASSWORD: isucon
+    profiles:
+      - db
+      - all
+networks:
+  frontend:
+  backend:

--- a/docker/app/golang/Dockerfile
+++ b/docker/app/golang/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.9
+
+COPY webapp/go /home/isucon/isubata/webapp/go
+WORKDIR /home/isucon/isubata/webapp/go
+RUN make
+
+EXPOSE 5000
+
+ENTRYPOINT ["/home/isucon/isubata/webapp/go/isubata"]

--- a/docker/bench/Dockerfile
+++ b/docker/bench/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.9
+
+COPY bench /home/isucon/isubata/bench
+WORKDIR /home/isucon/isubata/bench
+RUN \
+  go get github.com/constabulary/gb/... && \
+  gb vendor restore && \
+  make
+
+ENTRYPOINT ["bin/bench"]
+CMD ["-remotes", "web"]

--- a/docker/db/Dockerfile
+++ b/docker/db/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.9 AS build-dev
+
+COPY bench /home/isucon/isubata/bench
+COPY db /home/isucon/isubata/db
+WORKDIR /home/isucon/isubata/bench
+RUN \
+  go get github.com/constabulary/gb/... && \
+  gb vendor restore && \
+  make && \
+  bin/gen-initial-dataset
+
+FROM mysql:5.7
+
+ENV MYSQL_ALLOW_EMPTY_PASSWORD=yes MYSQL_DATABASE=isubata MYSQL_USER=isucon MYSQL_PASSWORD=isucon
+
+COPY --from=build-dev /home/isucon/isubata/db/isubata.sql /docker-entrypoint-initdb.d/01_isubata.sql
+COPY --from=build-dev /home/isucon/isubata/bench/isucon7q-initial-dataset.sql.gz /docker-entrypoint-initdb.d/isucon7q-initial-dataset.sql.gz 
+
+CMD ["--character-set-server=utf8mb4"]

--- a/docker/web-php/Dockerfile
+++ b/docker/web-php/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:1.10
+
+COPY webapp/public /home/isucon/isubata/webapp/public
+COPY webapp/php /home/isucon/isubata/webapp/php
+COPY docker/web-php/isucon.php.conf /etc/nginx/conf.d/isucon.php.conf

--- a/docker/web-php/isucon.php.conf
+++ b/docker/web-php/isucon.php.conf
@@ -1,0 +1,33 @@
+server {
+        listen 80 default_server;
+        listen [::]:80 default_server;
+        server_name isubata.example.com;
+
+        client_max_body_size 20M;
+
+        root /home/isucon/isubata/webapp/public;
+
+        location /favicon.ico { }
+        location /fonts/ { }
+        location /js/ { }
+        location /css/ { }
+
+        index index.php;
+        location / {
+                
+                if (!-f $request_filename) {
+                        rewrite ^(.+)$ /index.php$1 last;
+                }
+                proxy_set_header Host $http_host;
+                proxy_pass http://app:9000;
+        }
+
+        location ~ [^/]\.php(/|$) {
+                root           /home/isucon/isubata/webapp/php;
+                include        fastcgi_params;
+                fastcgi_index  index.php;
+                fastcgi_param  SCRIPT_FILENAME $document_root$fastcgi_script_name;
+                fastcgi_param  SCRIPT_NAME     $fastcgi_script_name;
+                fastcgi_pass   app:9000;
+        }
+}

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:1.10
+
+COPY webapp/public /home/isucon/isubata/webapp/public
+COPY docker/web/isucon.conf /etc/nginx/conf.d/isucon.conf

--- a/docker/web/isucon.conf
+++ b/docker/web/isucon.conf
@@ -1,0 +1,19 @@
+server {
+        listen 80 default_server;
+        listen [::]:80 default_server;
+        server_name isubata.example.com;
+
+        client_max_body_size 20M;
+
+        root /home/isucon/isubata/webapp/public;
+
+        location /favicon.ico { }
+        location /fonts/ { }
+        location /js/ { }
+        location /css/ { }
+
+        location / {
+                proxy_set_header Host $http_host;
+                proxy_pass http://app:5000;
+        }
+}


### PR DESCRIPTION
This pull request introduces a variety of changes to the `Makefile` and several `Dockerfile` configurations to streamline the setup and execution of different services using Docker Compose. The key changes include the addition of a default goal in the `Makefile`, the creation of Docker Compose configurations for multiple services, and the setup of Dockerfiles for different service components.

### Makefile Enhancements:
* Added a default goal to display help information and commands for running Docker Compose services. (`Makefile`)

### Docker Compose Configurations:
* Introduced a `docker-compose.yml` file to define and manage multiple services (`bench`, `web`, `app`, `db`) with specified build contexts, networks, dependencies, and profiles. (`docker-compose.yml`)

### Dockerfile Additions:
* Added a Dockerfile for the `app` service, setting up a Go environment, copying the application code, and defining the entry point. (`docker/app/golang/Dockerfile`)
* Added a Dockerfile for the `bench` service, setting up a Go environment, copying the benchmarking code, and defining the entry point and command. (`docker/bench/Dockerfile`)
* Added a Dockerfile for the `db` service, setting up a MySQL environment, and copying initial dataset scripts. (`docker/db/Dockerfile`)
* Added a Dockerfile for the `web` service, setting up an Nginx environment, and copying public assets and configuration. (`docker/web/Dockerfile`)

### Nginx Configuration:
* Added an Nginx configuration file for the `web` service to define server settings and proxy rules. (`docker/web/isucon.conf`)